### PR TITLE
Fix anchor on whitespace

### DIFF
--- a/src/comment-component.ts
+++ b/src/comment-component.ts
@@ -27,13 +27,9 @@ export class CommentComponent {
       </a>
       <div class="comment">
         <header class="comment-header">
-          <a class="text-link" href="${user.html_url}" target="_blank">
-            <strong>${user.login}</strong>
-          </a>
+          <a class="text-link" href="${user.html_url}" target="_blank"><strong>${user.login}</strong></a>
           commented
-          <a class="text-link" href="${html_url}" target="_blank">
-            ${timeAgo(Date.now(), new Date(created_at))}
-          </a>
+          <a class="text-link" href="${html_url}" target="_blank">${timeAgo(Date.now(), new Date(created_at))}</a>
         </header>
         <div class="markdown-body">
           ${body_html}


### PR DESCRIPTION
Avoid newlines inside anchor tags to prevent anchor highlighting on whitespace.

https://jsfiddle.net/mroliff/h67mn9dw/

![screen shot](https://user-images.githubusercontent.com/956290/33658195-b587c994-da73-11e7-9e6a-a0eda7f4cccb.png)
