### PR TITLE
GitHub usernames don't always begin with a letter

### DIFF
--- a/src/repo-regex.ts
+++ b/src/repo-regex.ts
@@ -1,1 +1,1 @@
-export default /^([a-z][\w-]+)\/([\w-.]+)$/i;
+export default /^([\w-]+)\/([\w-.]+)$/i;


### PR DESCRIPTION
I'd love to switch my site over to Utterances, but my username seems to be tripping up the repo regex 😅 Would there be any issues with removing the `[a-z]` from the beginning of it?