### PR TITLE
Support custom-css attribute to set custom CSS URL

### DIFF
--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -41,6 +41,11 @@ function readPageAttributes() {
     throw new Error(`Invalid repo: "${params.repo}"`);
   }
 
+  let customCss: string | null = null;
+  if ('custom-css' in params) {
+    customCss = params['custom-css'];
+  }
+
   return {
     owner: matches[1],
     repo: matches[2],
@@ -49,7 +54,8 @@ function readPageAttributes() {
     origin: params.origin,
     url: params.url,
     title: params.title,
-    description: params.description
+    description: params.description,
+    customCss
   };
 }
 

--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -41,11 +41,6 @@ function readPageAttributes() {
     throw new Error(`Invalid repo: "${params.repo}"`);
   }
 
-  let customCss: string | null = null;
-  if ('custom-css' in params) {
-    customCss = params['custom-css'];
-  }
-
   return {
     owner: matches[1],
     repo: matches[2],
@@ -55,7 +50,7 @@ function readPageAttributes() {
     url: params.url,
     title: params.title,
     description: params.description,
-    customCss
+    stylesheet: params.stylesheet
   };
 }
 

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -27,13 +27,15 @@ function loadIssue(): Promise<Issue | null> {
 
 function loadCustomStylesheet() {
   if (page.stylesheet) {
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = page.stylesheet;
-    link.setAttribute('crossorigin', 'anonymous');
-    document.head.appendChild(link);
-    return new Promise(resolve => { link.onolad = resolve; });
-    }
+    return new Promise(resolve => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.setAttribute('crossorigin', 'anonymous');
+      link.onload = resolve;
+      link.href = page.stylesheet;
+      document.head.appendChild(link);
+    });
+  }
   return Promise.resolve();
 }
 

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -25,6 +25,15 @@ function loadIssue(): Promise<Issue | null> {
   return loadIssueByTerm(page.issueTerm as string);
 }
 
+function injectCustomCss() {
+  if (page.customCss !== null) {
+    let link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = page.customCss;
+    document.head.appendChild(link);
+  }
+}
+
 Promise.all([loadIssue(), loadUser()])
   .then(([issue, user]) => bootstrap(issue, user));
 
@@ -75,6 +84,7 @@ function bootstrap(issue: Issue | null, user: User | null) {
 
   const newCommentComponent = new NewCommentComponent(user, submit);
   timeline.element.appendChild(newCommentComponent.element);
+  injectCustomCss();
   scheduleMeasure();
 }
 

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -25,16 +25,19 @@ function loadIssue(): Promise<Issue | null> {
   return loadIssueByTerm(page.issueTerm as string);
 }
 
-function injectCustomCss() {
-  if (page.customCss !== null) {
-    let link = document.createElement('link');
+function loadCustomStylesheet() {
+  if (page.stylesheet) {
+    const link = document.createElement('link');
     link.rel = 'stylesheet';
-    link.href = page.customCss;
+    link.href = page.stylesheet;
+    link.setAttribute('crossorigin', 'anonymous');
     document.head.appendChild(link);
-  }
+    return new Promise(resolve => { link.onolad = resolve; });
+    }
+  return Promise.resolve();
 }
 
-Promise.all([loadIssue(), loadUser()])
+Promise.all([loadIssue(), loadUser(), loadCustomStylesheet()])
   .then(([issue, user]) => bootstrap(issue, user));
 
 function bootstrap(issue: Issue | null, user: User | null) {
@@ -84,7 +87,6 @@ function bootstrap(issue: Issue | null, user: User | null) {
 
   const newCommentComponent = new NewCommentComponent(user, submit);
   timeline.element.appendChild(newCommentComponent.element);
-  injectCustomCss();
   scheduleMeasure();
 }
 


### PR DESCRIPTION
This is to implement some sort of custom theming for utterances elements. I [proposed one way of doing it][issue], by using `custom-css` attribute to set URL of desired CSS file to be loaded by the embeded `iframe`.
By doing this, users could write their own CSS to style utterances, since their blog styles do not always come along with the default GitHub theme.

[issue]: https://github.com/utterance/utterances/issues/49#issuecomment-415102655