### PR TITLE
Add GitHub dark orange theme

### DIFF
--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -111,6 +111,7 @@ export class ConfigurationComponent {
       <select id="theme" class="form-select" value="github-light">
         <option value="github-light">GitHub Light</option>
         <option value="github-dark">GitHub Dark</option>
+        <option value="github-dark-orange">GitHub Dark Orange</option>
       </select>
 
       <h3>Enable Utterances</h3>

--- a/src/stylesheets/themes/github-dark-orange/button.scss
+++ b/src/stylesheets/themes/github-dark-orange/button.scss
@@ -1,0 +1,12 @@
+@import "./variables";
+
+.btn-primary:disabled {
+  background: #376b39;
+}
+
+button[role=tab] {
+  color: $gray-600;
+  .selected {
+    color: $text-gray-dark;
+  }
+}

--- a/src/stylesheets/themes/github-dark-orange/code.scss
+++ b/src/stylesheets/themes/github-dark-orange/code.scss
@@ -1,0 +1,6 @@
+@import "./variables";
+
+.bg-gray-light,
+.bg-white {
+  background-color: $bg-gray !important;
+}

--- a/src/stylesheets/themes/github-dark-orange/combobox.scss
+++ b/src/stylesheets/themes/github-dark-orange/combobox.scss
@@ -1,0 +1,7 @@
+@import "./variables";
+
+.form-control, .form-select {
+  color: $text-gray-dark;
+  background-color: $bg-white !important;
+  border-radius: 3px;
+}

--- a/src/stylesheets/themes/github-dark-orange/comment.scss
+++ b/src/stylesheets/themes/github-dark-orange/comment.scss
@@ -1,0 +1,11 @@
+@import "./variables";
+
+.form-select {
+  background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAUAgMAAAD5DFXkAAAACVBMVEXMzMzMzMzMzMzgWE1NAAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfiCwMFBDi4mDGnAAAAR0lEQVQI123JIRUAIQAE0eUEgghEIAV5SEEEIiAQMCnZh74RX+xKr6+bNE3ZBjxBV4KpAlt/NTjKsBRhKED1ePzkZeIwoeoCtokT7bjAVYwAAAAASUVORK5CYII=) no-repeat right 8px center;
+  background-size: 8px 10px;
+}
+
+.markdown-body kbd {
+  background-color: transparent;
+  color: $text-gray-dark;
+}

--- a/src/stylesheets/themes/github-dark-orange/glow.scss
+++ b/src/stylesheets/themes/github-dark-orange/glow.scss
@@ -1,0 +1,18 @@
+@import "./variables";
+
+*:focus {
+  outline: none !important;
+  box-shadow: 0 0 0.2em 0.1em opacify($highlight, 0.1);
+  border-radius: 1px;
+}
+
+.tabnav-tab,
+.form-control,
+.form-select {
+  &.focus,
+  &:focus {
+    border-color: transparent;
+    box-shadow: 0 0 0 0.11em opacify($highlight, 0.1) !important;
+    outline-color: transparent;
+  }
+}

--- a/src/stylesheets/themes/github-dark-orange/heading.scss
+++ b/src/stylesheets/themes/github-dark-orange/heading.scss
@@ -1,0 +1,5 @@
+@import "./variables";
+
+h1, h2, h3, h4, h5, h6 {
+  border-color: $line !important;
+}

--- a/src/stylesheets/themes/github-dark-orange/index.scss
+++ b/src/stylesheets/themes/github-dark-orange/index.scss
@@ -1,0 +1,24 @@
+@import "./variables";
+@import "../../index";
+@import "./syntax";
+@import "./button.scss";
+@import "./glow.scss";
+@import "./heading.scss";
+@import "./comment.scss";
+@import "./selection.scss";
+@import "./placeholder.scss";
+@import "./combobox.scss";
+@import "./code.scss";
+
+body {
+  background-color: $bg-page;
+}
+
+iframe {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}

--- a/src/stylesheets/themes/github-dark-orange/placeholder.scss
+++ b/src/stylesheets/themes/github-dark-orange/placeholder.scss
@@ -1,0 +1,13 @@
+@import "./variables";
+
+@mixin placeholder {
+  ::placeholder { @content; }
+  ::-webkit-input-placeholder { @content; }
+  ::-moz-placeholder { @content; }
+  :-moz-placeholder { @content; }
+  :-ms-input-placeholder { @content; }
+}
+
+@include placeholder {
+  color: $text-gray-dark;
+}

--- a/src/stylesheets/themes/github-dark-orange/selection.scss
+++ b/src/stylesheets/themes/github-dark-orange/selection.scss
@@ -1,0 +1,15 @@
+@import "./variables";
+
+@mixin selection($element) {
+  #{$element}::-moz-selection { @content; }
+  #{$element}::selection { @content; }
+}
+
+@include selection("") {
+  background: $highlight;
+  color: $text-gray-dark !important;
+}
+
+@include selection("img") {
+  background: transparentize($highlight, 0.25);
+}

--- a/src/stylesheets/themes/github-dark-orange/syntax.scss
+++ b/src/stylesheets/themes/github-dark-orange/syntax.scss
@@ -1,0 +1,1 @@
+@import "github-syntax-dark/lib/github-dark";

--- a/src/stylesheets/themes/github-dark-orange/utterances.scss
+++ b/src/stylesheets/themes/github-dark-orange/utterances.scss
@@ -1,0 +1,11 @@
+@import "./variables";
+@import "../../utterances";
+@import "./syntax";
+@import "./button.scss";
+@import "./glow.scss";
+@import "./heading.scss";
+@import "./comment.scss";
+@import "./selection.scss";
+@import "./placeholder.scss";
+@import "./combobox.scss";
+@import "./code.scss";

--- a/src/stylesheets/themes/github-dark-orange/variables.scss
+++ b/src/stylesheets/themes/github-dark-orange/variables.scss
@@ -1,0 +1,20 @@
+$gray-000: #181818;
+$gray-100: #222222;
+$gray-200: #24292e;
+$gray-300: #4e4c4b;
+$gray-400: #586069;
+$gray-600: #bbbbbb;
+$gray-700: #959da5;
+$bg-white: #2d2833;
+$bg-gray: $gray-100;
+$bg-gray-light: darken($bg-gray, 5%);
+$border-gray: $gray-300;
+$border-gray-dark: $border-gray;
+$text-gray: #ffffff;
+$text-gray-dark: #ffffff;
+$text-blue: #f27052;
+$bg-blue-light: #212021;
+$bg-page: #463d4e;
+
+$highlight: rgba(242, 112, 82, 0.99);
+$line: #6f6e6e;


### PR DESCRIPTION
Adds a new theme `GitHub Dark Orange` which is
based on the existing `GitHub Dark` theme.

The theme uses a mix of dark greys with orange accents
on links and around currently focused elements.

# Screenshots
![u1](https://user-images.githubusercontent.com/7284672/52682382-16260880-2ef4-11e9-8596-49f193cffb17.png)
![u2](https://user-images.githubusercontent.com/7284672/52682380-16260880-2ef4-11e9-8f77-4f99c1d6b283.png)
![u3](https://user-images.githubusercontent.com/7284672/52682379-16260880-2ef4-11e9-9dce-8d49e680325e.png)
