### PR TITLE
Add ease in transition on add reactions button

### DIFF
--- a/src/reactions.ts
+++ b/src/reactions.ts
@@ -81,7 +81,7 @@ export function getReactionsMenuHtml(url: string, align: 'center' | 'right') {
     + `<span class="reaction-name" aria-hidden="true">${reactionNames[id]}</span>`;
   return `
   <details class="details-overlay details-popover reactions-popover">
-    <summary>${addReactionSvgs}</summary>
+    <summary ${align == 'center' ? 'tabindex="-1"' : ''}>${addReactionSvgs}</summary>
     <div class="Popover" style="${position}">
       <form class="Popover-message ${alignmentClass} box-shadow-large" action="javascript:">
         <span class="reaction-name">Pick your reaction</span>

--- a/src/stylesheets/reactions.scss
+++ b/src/stylesheets/reactions.scss
@@ -34,6 +34,7 @@
     padding: $spacer-2 $spacer-3;
     color: $text-gray;
     white-space: nowrap;
+    transition: opacity 0.3s ease-in-out;
     &:hover {
       color: $text-blue;
     }

--- a/src/stylesheets/timeline-comment.scss
+++ b/src/stylesheets/timeline-comment.scss
@@ -84,11 +84,18 @@
     border-top: $border;
 
     &[reaction-count="0"] {
-      display: none;
+      height: 0;
+      overflow: hidden;
+      opacity: 0;
     }
 
     &:not(:hover) .reactions-popover:not([open]) {
-      display: none;
+      height: 0;
+      overflow: hidden;
+      opacity: 0;
+      summary {
+        opacity: 0;
+      }
     }
   }
 


### PR DESCRIPTION
Adds an ease in transition on the add reactions button
in the comment footer.

Changed to more closely mimic how GitHub styles their buttons.