### PR TITLE
Prevent hovering on existing reactions from shifting buttons down

### DIFF
--- a/src/stylesheets/reactions.scss
+++ b/src/stylesheets/reactions.scss
@@ -8,7 +8,7 @@
   overflow-x: hidden;
   overflow-y: visible;
   > .reaction-button:last-child {
-    border-right: none!important;
+    border-right: 1.5px !important;
   }
 }
 
@@ -16,6 +16,8 @@
   font-weight: normal;
   padding: $spacer-2 $spacer-3;
   border-radius: 0!important;
+  border-right-width: 0px !important;
+  border-left-width: 1px !important;
 
   &[reaction-count="0"] {
     display: none;


### PR DESCRIPTION
Prior to this PR, in some cases, when highlighting an existing reaction,
the add reaction button would shift down to the right.

This would happen in circumstances where not all 8 reactions
were present on a comment.  This was due to buttons with no reaction
count being hidden with `display: none`.

Then Primer's button highlight CSS would add a border on the right
of the highlighted element and remove the left border on the following element.
This ensured that the row of buttons would remain a constant width.

However when some buttons were hidden, a border was added to the highlighted
element without the removal of a border from another element (since it was hidden).

This resulted in the row of buttons gaining a pixel, shifting everything down.

Resolved by removing Primer's border expanding behavior.

**Before**

![shift](https://user-images.githubusercontent.com/7284672/52937613-7b269780-3314-11e9-94f8-d35936b4a7bc.gif)

**After**

![noshift](https://user-images.githubusercontent.com/7284672/52937624-7feb4b80-3314-11e9-9a23-3c90d7a78766.gif)
