### PR TITLE
Prevent non-colored emojis from being invisible when selected

### DIFF
--- a/src/stylesheets/reactions.scss
+++ b/src/stylesheets/reactions.scss
@@ -70,6 +70,7 @@
     
     &:hover {
       transform: scale(1.2);
+      color: $text-blue !important;
     }
   }
 }


### PR DESCRIPTION
Prior to this PR, if a user did not have a font
that contained colored emojis, the reactions will fallback to a simple grayscale emoji.

However when hovering over a emoji from the reactions popover,
it would become invisible as a result of some hover CSS styling the color to white.

This commit resolves this by explicitly setting the color.

Behavior prior to this PR:

![invisble](https://user-images.githubusercontent.com/7284672/52937297-9e9d1280-3313-11e9-9b4f-6efbc1fbbcd0.gif)

