### PR TITLE
Fix link to your blog in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To comment, users must authorize the utterances app to post on their behalf usin
 ## sites using utterances
 
 * Haxe [documentation](https://haxe.org/manual) and [cookbook](https://code.haxe.org/)
-* [danyow.net](https://www.danyow.net)
+* [danyow.net](https://danyow.net)
 * [os.phil-opp.com](https://os.phil-opp.com/second-edition)
 * **[and many more...](https://github.com/utterance/utterances/blob/master/SITES.md#sites-using-utterances)**
 


### PR DESCRIPTION
It 404s currently, but works without the `www` prefix. Since the link on your profile page and in SITES.md doesn't have the `www` prefix, it should probably be removed.