### PR TITLE
Workaround for GitHub search API bug 

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -140,7 +140,7 @@ export function loadIssueByTerm(term: string) {
     return response.json();
   }).then(results => {
     for (const item of results.items) {
-      if (item.title === term) {
+      if (item.title.toLowerCase().indexOf(term.toLowerCase()) !== -1) {
         return item;
       }
     }

--- a/src/github.ts
+++ b/src/github.ts
@@ -139,14 +139,12 @@ export function loadIssueByTerm(term: string) {
     }
     return response.json();
   }).then(results => {
-    if (results.total_count === 0) {
-      return null;
+    for (const item of results.items) {
+      if (item.title === term) {
+        return item;
+      }
     }
-    if (results.total_count > 1) {
-      // tslint:disable-next-line:no-console
-      console.warn(`Multiple issues match "${q}". Using earliest created.`);
-    }
-    return results.items[0];
+    return null;
   });
 }
 


### PR DESCRIPTION
If an issue title contains a number that is surrounded by two spaces, the `in:title` search qualifier is ignored, and the `number` property of issues is also taken into account. Issues that are returned based on said `number` property also always have a `score` of 100, which places them before the actual issue.

To work around this limitation, the `og:title` issue lookup function now iterates over all returned issues and returns the first one that exactly matches the OpenGraph title.