### PR TITLE
Fix 'Sign in' link in reaction box to load outside iframe

### DIFF
--- a/src/reactions.ts
+++ b/src/reactions.ts
@@ -106,7 +106,7 @@ export function getSignInToReactMenuHtml(align: 'center' | 'right') {
     <summary aria-label="Reactions Menu">${addReactionSvgs}</summary>
     <div class="Popover" style="${position}">
       <div class="Popover-message ${alignmentClass} box-shadow-large" style="padding: 16px">
-        <span><a href="${getLoginUrl(pageAttributes.url)}">Sign in</a> to add your reaction.</span>
+        <span><a href="${getLoginUrl(pageAttributes.url)}" target="_top">Sign in</a> to add your reaction.</span>
       </div>
     </div>
   </details>`;


### PR DESCRIPTION
Thanks for @utterance, I've started using this a few days ago and it works really well, except for this minor issue I've noticed:

When an unauthenticated user views a comment and wants to leave a reaction, this is the dropdown that asks them to authenticate first:
![Screenshot_2019-09-17 Brief note New blog engine](https://user-images.githubusercontent.com/776829/65025061-4922f580-d936-11e9-8244-b84cdfd9860e.png)

However, clicking the 'Sign in' link yields the following error message in this iframe:

![](https://i.imgur.com/bXMbRw4.png)

The problem appears to be that it's trying to render the login box in this iframe (which GitHub prohibits). In contrast, the green "Sign in to comment" button at the bottom works just fine (and loads in the top frame). Similarly, once logged in, leaving reactions works just fine.

I've attached this minimal patch to make sure both links use the `target="_top"` attribute. Let me know if anything's missing.