### PR TITLE
Reverse order of comments

### DIFF
--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -135,6 +135,14 @@ export class ConfigurationComponent {
         <option value="photon-dark">Photon Dark</option>
       </select>
 
+      <h3 id="heading-reverse-order">Reverse Order</h3>
+      <p>
+        Choose if you want the order of comments to be reversed and put
+        the input form on top.
+      </p>
+      <input type="checkbox" id="reverse-order" />
+      Reverse order, input form on top
+
       <h3 id="heading-enable">Enable Utterances</h3>
 
       <p>Add the following script tag to your blog's template. Position it where you want the
@@ -156,6 +164,8 @@ export class ConfigurationComponent {
     this.label = this.element.querySelector('#label') as HTMLInputElement;
 
     this.theme = this.element.querySelector('#theme') as HTMLSelectElement;
+
+    this.reverseOrder = this.element.querySelector('#reverse-order')  as HTMLInputElement;
 
     const themeStylesheet = document.getElementById('theme-stylesheet') as HTMLLinkElement;
     this.theme.addEventListener('change', () => {
@@ -189,17 +199,29 @@ export class ConfigurationComponent {
     } else {
       mappingAttr = this.makeConfigScriptAttribute('issue-term', mapping.value);
     }
+    let orderConfig : string = '';
+    if (this.reverseOrder.checked) {
+      console.log(this.reverseOrder);
+      orderConfig = this.makeConfigScriptFlag('reverse-order', true) + '\n' +
+                    this.makeConfigScriptFlag('input-position-top', true) + '\n';
+    }
     this.script.innerHTML = this.makeConfigScript(
       this.makeConfigScriptAttribute('repo', this.repo.value === '' ? '[ENTER REPO HERE]' : this.repo.value) + '\n' +
       mappingAttr + '\n' +
       (this.label.value ? this.makeConfigScriptAttribute('label', this.label.value) + '\n' : '') +
       this.makeConfigScriptAttribute('theme', this.theme.value) + '\n' +
+      orderConfig +
       this.makeConfigScriptAttribute('crossorigin', 'anonymous'));
   }
 
   private makeConfigScriptAttribute(name: string, value: string) {
     // tslint:disable-next-line:max-line-length
     return `<span class="pl-s1">        <span class="pl-e">${name}</span>=<span class="pl-s"><span class="pl-pds">"</span>${value}<span class="pl-pds">"</span></span></span>`;
+  }
+
+  private makeConfigScriptFlag(name: string, value: boolean) {
+    // tslint:disable-next-line:max-line-length
+    return `<span class="pl-s1">        <span class="pl-e">${name}</span>=<span class="pl-s">${value}</span></span>`;
   }
 
   private makeConfigScript(attrs: string) {

--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -140,8 +140,14 @@ export class ConfigurationComponent {
         Choose if you want the order of comments to be reversed and put
         the input form on top.
       </p>
-      <input type="checkbox" id="reverse-order" />
-      Reverse order, input form on top
+      <p>
+        Related parameters ("reverse-order" and "input-position-top") accept
+        both boolean primitives and strings (both true and "true" are valid).
+      </p>
+      <label>
+        <input type="checkbox" id="reverse-order" />
+        Reverse order, input form on top
+      </label>
 
       <h3 id="heading-enable">Enable Utterances</h3>
 
@@ -201,9 +207,9 @@ export class ConfigurationComponent {
     }
     let orderConfig : string = '';
     if (this.reverseOrder.checked) {
-      console.log(this.reverseOrder);
-      orderConfig = this.makeConfigScriptFlag('reverse-order', true) + '\n' +
-                    this.makeConfigScriptFlag('input-position-top', true) + '\n';
+      // using strings to encode booleans - because `deparam` uses only strings
+      orderConfig = this.makeConfigScriptAttribute('reverse-order', 'true') + '\n' +
+                    this.makeConfigScriptAttribute('input-position-top', 'true') + '\n';
     }
     this.script.innerHTML = this.makeConfigScript(
       this.makeConfigScriptAttribute('repo', this.repo.value === '' ? '[ENTER REPO HERE]' : this.repo.value) + '\n' +
@@ -217,11 +223,6 @@ export class ConfigurationComponent {
   private makeConfigScriptAttribute(name: string, value: string) {
     // tslint:disable-next-line:max-line-length
     return `<span class="pl-s1">        <span class="pl-e">${name}</span>=<span class="pl-s"><span class="pl-pds">"</span>${value}<span class="pl-pds">"</span></span></span>`;
-  }
-
-  private makeConfigScriptFlag(name: string, value: boolean) {
-    // tslint:disable-next-line:max-line-length
-    return `<span class="pl-s1">        <span class="pl-e">${name}</span>=<span class="pl-s">${value}</span></span>`;
   }
 
   private makeConfigScript(attrs: string) {

--- a/src/index.html
+++ b/src/index.html
@@ -72,6 +72,8 @@
               issue-term="homepage"
               crossorigin="anonymous"
               theme="github-light"
+              input-position-top=false
+              reverse-order=false
               async>
       </script>
     </if>
@@ -83,6 +85,7 @@
               crossorigin="anonymous"
               theme="github-light"
               input-position-top=false
+              reverse-order=false
               async>
       </script>
     </else>

--- a/src/index.html
+++ b/src/index.html
@@ -82,6 +82,7 @@
               label="💬 comment"
               crossorigin="anonymous"
               theme="github-light"
+              input-position-top=false
               async>
       </script>
     </else>

--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -47,6 +47,7 @@ function readPageAttributes() {
   }
 
   let inputPositionTop : bool = params['input-position-top'] == "true";
+  let reverseOrder : bool = params['reverse-order'] == "true";
 
   return {
     owner: matches[1],
@@ -59,7 +60,8 @@ function readPageAttributes() {
     description: params.description,
     label: params.label,
     theme: params.theme || 'github-light',
-    inputPositionTop: inputPositionTop
+    inputPositionTop: inputPositionTop,
+    reverseOrder: reverseOrder
   };
 }
 

--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -46,6 +46,8 @@ function readPageAttributes() {
     token.value = params.token;
   }
 
+  let inputPositionTop : bool = params['input-position-top'] == "true";
+
   return {
     owner: matches[1],
     repo: matches[2],
@@ -56,7 +58,8 @@ function readPageAttributes() {
     title: params.title,
     description: params.description,
     label: params.label,
-    theme: params.theme || 'github-light'
+    theme: params.theme || 'github-light',
+    inputPositionTop: inputPositionTop
   };
 }
 

--- a/src/timeline-component.ts
+++ b/src/timeline-component.ts
@@ -1,6 +1,8 @@
 import { User, Issue, IssueComment } from './github';
 import { CommentComponent } from './comment-component';
 import { scheduleMeasure } from './measure';
+import { pageAttributes as page } from './page-attributes';
+
 
 export class TimelineComponent {
   public readonly element: HTMLElement;
@@ -55,7 +57,13 @@ export class TimelineComponent {
       comment,
       this.user ? this.user.login : null);
 
-    const index = this.timeline.findIndex(x => x.comment.id >= comment.id);
+    if (page.reverseOrder) {
+      const indexSearchCondition = (x => x.comment.id <= comment.id);
+    } else {
+      const indexSearchCondition = (x => x.comment.id >= comment.id);
+    }
+
+    const index = this.timeline.findIndex(indexSearchCondition);
     if (index === -1) {
       this.timeline.push(component);
       this.element.insertBefore(component.element, this.marker);

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -72,7 +72,11 @@ async function bootstrap() {
   };
 
   const newCommentComponent = new NewCommentComponent(user, submit);
-  timeline.element.appendChild(newCommentComponent.element);
+  if (page.inputPositionTop) {
+    timeline.element.insertAdjacentElement('afterbegin', newCommentComponent.element);
+  } else {
+    timeline.element.appendChild(newCommentComponent.element);
+  }
 }
 
 bootstrap();


### PR DESCRIPTION
Closes #182 

Added options to reverse order of comments and put the input form above comments, instead of below. As most of the time I expect either both or none of them to be used, they are handled by a common checkbox in the config generator.

Overall it seems to work, but I have not tested it on cases with hidden pages (I have not seen any).

Example config (from the `configuration-component`):
```html
<script src="https://utteranc.es/client.js"
        repo="[ENTER REPO HERE]"
        issue-term="pathname"
        theme="github-light"
        reverse-order="true"
        input-position-top="true"
        crossorigin="anonymous"
        async>
</script>
```


