### PR TITLE
Add Boxy Light theme

### DIFF
--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -136,6 +136,7 @@ export class ConfigurationComponent {
         <option value="icy-dark">Icy Dark</option>
         <option value="dark-blue">Dark Blue</option>
         <option value="photon-dark">Photon Dark</option>
+        <option value="boxy-light">Boxy Light</option>
       </select>
 
       <h3 id="heading-enable">Enable Utterances</h3>

--- a/src/stylesheets/themes/boxy-light/index.scss
+++ b/src/stylesheets/themes/boxy-light/index.scss
@@ -1,6 +1,2 @@
 @import "../../index";
 @import "./syntax";
-
-.utterances {
-  max-width: unset;
-}

--- a/src/stylesheets/themes/boxy-light/index.scss
+++ b/src/stylesheets/themes/boxy-light/index.scss
@@ -1,0 +1,6 @@
+@import "../../index";
+@import "./syntax";
+
+.utterances {
+  max-width: unset;
+}

--- a/src/stylesheets/themes/boxy-light/syntax.scss
+++ b/src/stylesheets/themes/boxy-light/syntax.scss
@@ -1,0 +1,6 @@
+@import "github-syntax-light/lib/github-light";
+
+// adjust syntax highlighting to ensure WCAG AAA rating
+.pl-ent {
+  color: #196128;
+}

--- a/src/stylesheets/themes/boxy-light/utterances.scss
+++ b/src/stylesheets/themes/boxy-light/utterances.scss
@@ -1,0 +1,19 @@
+$border-radius: 0;
+
+@import "../../utterances";
+@import "./syntax";
+
+.reactions-popover {
+  summary {
+    outline: none;
+  }
+}
+
+.tabnav-tab.selected, .tabnav-tab[aria-selected=true], .tabnav-tab[aria-current], .tabnav-tab:focus {
+  outline: none;
+}
+
+.btn {
+  border-radius: $border-radius;
+  background-image: unset;
+}


### PR DESCRIPTION
Add Boxy Light theme, which is based on GitHub Light and removes all border-radius and button gradient to form a flat style.
This theme also removes the hardcoded `max-width` limit from `.utterances` class, enabling website owners to improve the comment visual for wide screen devices.