### PR TITLE
WIP: Reactions on main post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ chrome
 dist
 node_modules
 yarn-error.log
+.idea

--- a/src/post-reaction-component.ts
+++ b/src/post-reaction-component.ts
@@ -1,0 +1,115 @@
+import { Issue, ReactionID, Reactions, reactionTypes, toggleReaction } from './github';
+import { reactionEmoji, reactionNames } from './reactions';
+
+class EmptyReactions implements Reactions {
+  '+1' = 0;
+  '-1' = 0;
+  confused = 0;
+  eyes = 0;
+  heart = 0;
+  hooray = 0;
+  laugh = 0;
+  rocket = 0;
+  // tslint:disable-next-line:variable-name
+  total_count = 0;
+  url = '';
+}
+
+export class PostReactionComponent {
+  public readonly element: HTMLElement;
+  private readonly countAnchor: HTMLAnchorElement;
+  private readonly reactionListContainer: HTMLFormElement;
+  private reactions: Reactions = new EmptyReactions();
+  private reactionsCount: number = 0;
+  private issueURL: string = '';
+
+  constructor(
+    private issue: Issue | null,
+    private createIssue: () => Promise<null>
+  ) {
+    this.element = document.createElement('section');
+    this.element.classList.add('post-reactions');
+    this.element.innerHTML = `
+      <header>
+        <a class="text-link" target="_blank"></a>
+      </header>
+       <form class="post-reaction-list BtnGroup" action="javascript:">
+       </form>`;
+    this.countAnchor = this.element.querySelector('header a') as HTMLAnchorElement;
+    this.reactionListContainer = this.element.querySelector('.post-reaction-list') as HTMLFormElement;
+    this.setIssue(this.issue)
+    this.render();
+    this.setupSubmitHandler();
+  }
+
+  public setIssue(issue: Issue | null) {
+    this.issue = issue;
+    if (issue) {
+      this.reactions = issue.reactions;
+      this.reactionsCount = issue.reactions.total_count;
+      this.issueURL = issue.html_url;
+      this.render();
+    }
+  }
+
+  private setupSubmitHandler() {
+    const handler = async (event: Event) => {
+      event.preventDefault();
+
+      const issueExists = !!this.issue;
+      if (!issueExists) {
+        await this.createIssue();
+      }
+
+      const button = event.target as HTMLButtonElement;
+      button.disabled = true;
+      const url = button.formAction;
+      const id = button.value as ReactionID;
+      const {deleted} = await toggleReaction(url, id);
+      const selector = `button[post-reaction][formaction="${url}"][value="${id}"],[reaction-count][reaction-url="${url}"]`;
+      const elements = Array.from(this.element.querySelectorAll(selector));
+      const delta = deleted ? -1 : 1;
+      for (const element of elements) {
+        element.setAttribute(
+          'reaction-count',
+          (parseInt(element.getAttribute('reaction-count')!, 10) + delta).toString());
+      }
+      button.disabled = false;
+    }
+
+    const buttons = this.element.querySelectorAll('button[post-reaction]');
+    buttons.forEach(button => button.addEventListener('click', handler, true))
+  }
+
+  private getSubmitButtons(): string {
+    function buttonFor(url: string, reaction: ReactionID, disabled: boolean, count: number): string {
+      return `
+        <button
+          post-reaction
+          type="submit"
+          action="javascript:"
+          formaction="${url}"
+          class="btn BtnGroup-item btn-outline post-reaction-button"
+          value="${reaction}"
+          aria-label="Toggle ${reactionNames[reaction]} reaction"
+          reaction-count="${count}"
+          ${disabled ? 'disabled' : ''}>
+          ${reactionEmoji[reaction]}
+        </button>`;
+    }
+
+    return reactionTypes
+      .map(id => buttonFor(this.reactions.url, id, false, this.reactions[id]))
+      .join('')
+  }
+
+  private render() {
+    if (this.issueURL !== '') {
+      this.countAnchor.href = this.issueURL;
+    } else {
+      this.countAnchor.removeAttribute('href');
+    }
+    this.countAnchor.textContent = `${this.reactionsCount} Reaction${this.reactionsCount === 1 ? '' : 's'}`;
+    this.reactionListContainer.innerHTML = this.getSubmitButtons();
+  }
+}

--- a/src/post-reaction-component.ts
+++ b/src/post-reaction-component.ts
@@ -1,19 +1,5 @@
 import { Issue, ReactionID, Reactions, reactionTypes, toggleReaction } from './github';
-import { reactionEmoji, reactionNames } from './reactions';
-
-class EmptyReactions implements Reactions {
-  '+1' = 0;
-  '-1' = 0;
-  confused = 0;
-  eyes = 0;
-  heart = 0;
-  hooray = 0;
-  laugh = 0;
-  rocket = 0;
-  // tslint:disable-next-line:variable-name
-  total_count = 0;
-  url = '';
-}
+import { EmptyReactions, reactionEmoji, reactionNames } from './reactions';
 
 export class PostReactionComponent {
   public readonly element: HTMLElement;
@@ -39,7 +25,6 @@ export class PostReactionComponent {
     this.reactionListContainer = this.element.querySelector('.post-reaction-list') as HTMLFormElement;
     this.setIssue(this.issue)
     this.render();
-    this.setupSubmitHandler();
   }
 
   public setIssue(issue: Issue | null) {
@@ -111,5 +96,6 @@ export class PostReactionComponent {
     }
     this.countAnchor.textContent = `${this.reactionsCount} Reaction${this.reactionsCount === 1 ? '' : 's'}`;
     this.reactionListContainer.innerHTML = this.getSubmitButtons();
+    this.setupSubmitHandler();
   }
 }

--- a/src/reactions.ts
+++ b/src/reactions.ts
@@ -1,4 +1,4 @@
-import { toggleReaction, ReactionID, reactionTypes } from './github';
+import { ReactionID, Reactions, reactionTypes, toggleReaction } from './github';
 import { getLoginUrl } from './oauth';
 import { pageAttributes } from './page-attributes';
 import { scheduleMeasure } from './measure';
@@ -24,6 +24,20 @@ export const reactionEmoji: Record<ReactionID, string> = {
   'rocket': '🚀',
   'eyes': '👀'
 };
+
+export class EmptyReactions implements Reactions {
+  '+1' = 0;
+  '-1' = 0;
+  confused = 0;
+  eyes = 0;
+  heart = 0;
+  hooray = 0;
+  laugh = 0;
+  rocket = 0;
+  // tslint:disable-next-line:variable-name
+  total_count = 0;
+  url = '';
+}
 
 export function getReactionHtml(url: string, reaction: ReactionID, disabled: boolean, count: number) {
   return `

--- a/src/stylesheets/post-reactions.scss
+++ b/src/stylesheets/post-reactions.scss
@@ -1,0 +1,19 @@
+.post-reactions {
+  margin: $spacer-3 0;
+  padding: 0 $spacer-1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .post-reaction-list > .post-reaction-button {
+    font-weight: normal;
+    padding: $spacer-2 $spacer-3;
+    border-radius: 0 !important;
+
+    &::after {
+      display: inline-block;
+      margin-left: 2px;
+      content: attr(reaction-count);
+    }
+  }
+}

--- a/src/stylesheets/utterances.scss
+++ b/src/stylesheets/utterances.scss
@@ -8,6 +8,7 @@
 @import "@primer/css/forms/form-control";
 @import "@primer/css/popover/index";
 @import "./util";
+@import "./post-reactions";
 @import "./timeline";
 @import "./timeline-comment";
 @import "./permalink-code";

--- a/src/timeline-component.ts
+++ b/src/timeline-component.ts
@@ -13,7 +13,7 @@ export class TimelineComponent {
     private user: User | null,
     private issue: Issue | null
   ) {
-    this.element = document.createElement('main');
+    this.element = document.createElement('section');
     this.element.classList.add('timeline');
     this.element.innerHTML = `
       <h1 class="timeline-header">

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -45,13 +45,14 @@ async function bootstrap() {
 
   const timeline = new TimelineComponent(user, issue);
   const createIssue = async () => {
-    issue = await createGitHubIssue(
+    const newIssue = await createGitHubIssue(
       page.issueTerm as string,
       page.url,
       page.title,
       page.description || '',
       page.label
     )
+    issue = await loadIssueByNumber(newIssue.number)
     timeline.setIssue(issue);
     postReactionComponent.setIssue(issue);
   }
@@ -74,15 +75,7 @@ async function bootstrap() {
   const submit = async (markdown: string) => {
     await assertOrigin();
     if (!issue) {
-      issue = await createGitHubIssue(
-        page.issueTerm as string,
-        page.url,
-        page.title,
-        page.description || '',
-        page.label
-      );
-      timeline.setIssue(issue);
-      postReactionComponent.setIssue(issue)
+      await createIssue();
     }
     const comment = await postComment(issue.number, markdown);
     timeline.insertComment(comment, true);

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -29,6 +29,9 @@ function loadIssue(): Promise<Issue | null> {
 }
 
 async function bootstrap() {
+  const main = document.createElement('main');
+  document.body.appendChild(main);
+
   await loadToken();
   // tslint:disable-next-line:prefer-const
   let [issue, user] = await Promise.all([
@@ -40,7 +43,7 @@ async function bootstrap() {
   startMeasuring(page.origin);
 
   const timeline = new TimelineComponent(user, issue);
-  document.body.appendChild(timeline.element);
+  main.appendChild(timeline.element);
 
   if (issue && issue.comments > 0) {
     renderComments(issue, timeline);


### PR DESCRIPTION
Related issue: #188 

This is a work in progress PR. Lot of things to implemented/handled.

Done:
1. Show/submit reactions for existing issue
2. Show/submit reaction on new issue created by first comment
3. Show total reaction count

Pending things on top of my head:
1. Fix error when reacting on new issue created through a reactions button
2. Fix issue with updating the reaction count
3. Disable when user is not logged in
4. UI for showing "signin to react"
5. Style for various themes

Currently it looks like this:

<img width="870" alt="Screenshot 2020-06-15 at 12 03 43 AM" src="https://user-images.githubusercontent.com/6568319/84601134-c666a100-ae9b-11ea-80cc-f870b5e16b2e.png">
