### PR TITLE
Option to not display new comment form

### DIFF
--- a/src/new-comment-link.ts
+++ b/src/new-comment-link.ts
@@ -1,0 +1,20 @@
+import { Issue } from './github';
+
+export class NewCommentLink {
+  public readonly element: HTMLElement;
+
+  constructor(
+    private readonly jump: () => void
+  ) {
+    this.element = document.createElement('article');
+    this.element.classList.add('timeline-comment');
+
+    this.element.innerHTML = `
+      <div class="new-comment-footer" style="width: 100%;">
+        <span class="timeline-header">Comments are recorded using GitHub Issues</span>
+        <button class="btn btn-primary btn-large" target="_blank">Comment on GitHub</button>
+      </div>`;
+
+    this.element.lastChild.lastElementChild.addEventListener('click', this.jump);
+  }
+}

--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -56,7 +56,8 @@ function readPageAttributes() {
     title: params.title,
     description: params.description,
     label: params.label,
-    theme: params.theme || 'github-light'
+    theme: params.theme || 'github-light',
+    form: params.form
   };
 }
 


### PR DESCRIPTION
#355 
Added optional argument `form` to the `script` tag.

If `form=false`, the `new-comment-component` is replaced by a button that links to the issue.
<img width="744" alt="1" src="https://user-images.githubusercontent.com/39925558/89110445-8efb8600-d442-11ea-9e08-11bb9ca72640.png">

If the issue does not exist, an error message is displayed.
<img width="795" alt="2" src="https://user-images.githubusercontent.com/39925558/89110451-a175bf80-d442-11ea-8127-16bf4f377e12.png">

What it looks like:
<img width="793" alt="3" src="https://user-images.githubusercontent.com/39925558/89110471-cbc77d00-d442-11ea-817f-20dc6dae7932.png">
