### PR TITLE
Dynamic page size [non-breaking change]

### DIFF
--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -146,6 +146,11 @@ export class ConfigurationComponent {
       </p>
       <div class="config-field" id="script" class="highlight highlight-text-html-basic"></div>
       <button id="copy-button" type="button" class="btn btn-blue code-action">Copy</button>
+
+      <p>There is an <em>optional</em> argument <code>size</code> that specifies the number of comments to be displayed before the
+      rest are folded. The default value is 25. For example, <code>size=2</code> will format the timeline as two comments,
+      expand button, then at most three other comments.
+      </p>
       <br/>
       <br/>`;
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -7,8 +7,6 @@ const GITHUB_ENCODING__HTML_JSON = 'application/vnd.github.VERSION.html+json';
 const GITHUB_ENCODING__HTML = 'application/vnd.github.VERSION.html';
 const GITHUB_ENCODING__REACTIONS_PREVIEW = 'application/vnd.github.squirrel-girl-preview';
 
-export const PAGE_SIZE = 25;
-
 export type ReactionID = '+1' | '-1' | 'laugh' | 'hooray' | 'confused' | 'heart' | 'rocket' | 'eyes';
 
 export const reactionTypes: ReactionID[] = ['+1', '-1', 'laugh', 'hooray', 'confused', 'heart', 'rocket', 'eyes'];
@@ -168,16 +166,16 @@ export function loadIssueByNumber(issueNumber: number) {
   });
 }
 
-function commentsRequest(issueNumber: number, page: number) {
-  const url = `repos/${owner}/${repo}/issues/${issueNumber}/comments?page=${page}&per_page=${PAGE_SIZE}`;
+function commentsRequest(issueNumber: number, page: number, size: number) {
+  const url = `repos/${owner}/${repo}/issues/${issueNumber}/comments?page=${page}&per_page=${size}`;
   const request = githubRequest(url);
   const accept = `${GITHUB_ENCODING__HTML_JSON},${GITHUB_ENCODING__REACTIONS_PREVIEW}`;
   request.headers.set('Accept', accept);
   return request;
 }
 
-export function loadCommentsPage(issueNumber: number, page: number): Promise<IssueComment[]> {
-  const request = commentsRequest(issueNumber, page);
+export function loadCommentsPage(issueNumber: number, page: number, size: number): Promise<IssueComment[]> {
+  const request = commentsRequest(issueNumber, page, size);
   return githubFetch(request).then(response => {
     if (!response.ok) {
       throw new Error('Error fetching comments.');

--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -56,7 +56,8 @@ function readPageAttributes() {
     title: params.title,
     description: params.description,
     label: params.label,
-    theme: params.theme || 'github-light'
+    theme: params.theme || 'github-light',
+    size: Math.round(Math.abs(+params.size)) || 25
   };
 }
 


### PR DESCRIPTION
Related to #344. Added `size` optional argument, equaling 25 if not specified so existing users will not notice any difference. This addresses the issue of extra-long comment sections, causing scrolling difficulties.

If the specified size is less than 16, the hidden-page size will increase exponentially until 16 is reached, avoiding problems with rate limiting.

If the specified size is larger or equal to 16, the hidden-page size will be equal to the specified size. E.g. if no `size` argument is passed in, the hidden-page size will default to a constant of 25, which is the same as before.

As the page size is now dynamic, logic to include penultimate page was also modified to be less than half of the given page size.

Setting `size=1`:
<img width="801" alt="1" src="https://user-images.githubusercontent.com/39925558/89207406-93df4780-d5b2-11ea-91dc-ea9cd03cfc4e.png">


