### PR TITLE
add new theme dark mood

### DIFF
--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -137,6 +137,7 @@ export class ConfigurationComponent {
         <option value="dark-blue">Dark Blue</option>
         <option value="photon-dark">Photon Dark</option>
         <option value="boxy-light">Boxy Light</option>
+        <option value="dark-mood">Dark Mood</option>
       </select>
 
       <h3 id="heading-enable">Enable Utterances</h3>

--- a/src/stylesheets/themes/dark-mood/button.scss
+++ b/src/stylesheets/themes/dark-mood/button.scss
@@ -1,0 +1,14 @@
+.btn-primary {
+  background: linear-gradient(#407045, #305530);
+  border-color: #083;
+  color: #e2e2e2;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(#508055, #407045);
+}
+
+.btn-primary:disabled {
+  background: linear-gradient(#203522, #152715);
+  border-color: #041;
+}

--- a/src/stylesheets/themes/dark-mood/index.scss
+++ b/src/stylesheets/themes/dark-mood/index.scss
@@ -1,0 +1,4 @@
+@import "./variables";
+@import "../../index";
+@import "./syntax";
+@import "./button.scss";

--- a/src/stylesheets/themes/dark-mood/syntax.scss
+++ b/src/stylesheets/themes/dark-mood/syntax.scss
@@ -1,0 +1,1 @@
+@import "github-syntax-dark/lib/github-dark";

--- a/src/stylesheets/themes/dark-mood/utterances.scss
+++ b/src/stylesheets/themes/dark-mood/utterances.scss
@@ -1,0 +1,4 @@
+@import "./variables";
+@import "../../utterances";
+@import "./syntax";
+@import "./button.scss";

--- a/src/stylesheets/themes/dark-mood/variables.scss
+++ b/src/stylesheets/themes/dark-mood/variables.scss
@@ -1,0 +1,18 @@
+$gray-000: #0D1117;
+$gray-100: #222;
+$gray-200: #24292e;
+$gray-300: #343434;
+$gray-400: #586069;
+$gray-600: #7b7b7b;
+$gray-700: #959da5;
+$bg-white: #0D1117;
+$bg-gray: #090D13;
+$bg-gray-light: darken($bg-gray, 5%);
+$border-gray: $gray-300;
+$border-gray-dark: $border-gray;
+$text-gray: #949494;
+$text-gray-dark: #C9D1D9;
+$text-blue: rgb(65, 131, 196);
+$bg-blue-light: #182030;
+$black-fade-15: rgba(#fff, 0.15);
+$black-fade-30: rgba(#fff, 0.3);


### PR DESCRIPTION
Hello! 

Here's a new theme that is based off 'github-dark' to match Github's current Dark Mode.

We had a brief discussion (https://github.com/utterance/utterances/issues/462) and I realize the "github-dark" theme will be updated when Primer is updated. This made me think it might be useful to create a separate theme, so that changes to Primer or GitHub's Dark Mode won't affect the theme.

I named it dark-mood, and I'm not attached to it, so if you want to rename go for it!

Please let me know if anything else is needed.

Thank you! 

Here's a screenshots, from my local build:
![dark-mood](https://user-images.githubusercontent.com/5334269/104036537-83567d00-51a1-11eb-99fd-21a3b7da527c.PNG)
![dark-mood2](https://user-images.githubusercontent.com/5334269/104039214-1690b200-51a4-11eb-99d3-c972a8a99c63.PNG)