### PR TITLE
Create a new issue when the search didn't find the exact title

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -153,8 +153,8 @@ export function loadIssueByTerm(term: string) {
       }
     }
     // tslint:disable-next-line:no-console
-    console.warn(`Issue search results do not contain an issue with title matching "${term}". Using first result.`);
-    return results.items[0];
+    console.warn(`Issue search results do not contain an issue with title matching "${term}".`);
+    return null;
   });
 }
 


### PR DESCRIPTION
Instead of loading the first result in the fuzzy search, how about creating a new issue with the exact title? Then we would be more certain about which issue corresponds to which page. For example, if the page URL (pathname) is `foo/`, but the issue with the title `foo/` doesn't exist, and two issues with titles `hello foo` and `bye foo` exist. In this case, Utterances will map comments to the issue `hello foo`. I feel it would be better if it creates a new issue with the title `foo/` instead.

Basically it boils down to the decision on whether you want to risk loading a wrong issue for comments, or creating a new but unnecessary issue (e.g., `hello foo` might be the right issue for the page `foo/`) when an exact match of the title is not found in existing issues. I feel the former is worse than the latter.