### PR TITLE
Add crossorigin="anonymous" to iframe

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -82,7 +82,7 @@ const url = `${utterancesOrigin}/utterances.html`;
 script.insertAdjacentHTML(
   'afterend',
   `<div class="utterances">
-    <iframe class="utterances-frame" title="Comments" scrolling="no" src="${url}?${param(attrs)}" loading="lazy"></iframe>
+    <iframe class="utterances-frame" title="Comments" scrolling="no" src="${url}?${param(attrs)}" loading="lazy" crossorigin="anonymous"></iframe>
   </div>`);
 const container = script.nextElementSibling as HTMLDivElement;
 script.parentElement!.removeChild(script);


### PR DESCRIPTION
This allows utteranc.es to support the relatively new Cross-Origin-Embedder-Policy when it is set to `require-corp`.

Fixes #527