### PR TITLE
Optimize the "tabnav-tab" button

### DIFF
--- a/src/stylesheets/themes/github-dark-orange/button.scss
+++ b/src/stylesheets/themes/github-dark-orange/button.scss
@@ -4,9 +4,13 @@
   background: #376b39;
 }
 
-button[role=tab] {
+button[role="tab"] {
   color: $gray-600;
   .selected {
     color: $text-gray-dark;
   }
+}
+
+.tabnav-tab:focus-visible {
+  border-radius: 6px 6px 0 0 !important;
 }

--- a/src/stylesheets/themes/github-dark-orange/glow.scss
+++ b/src/stylesheets/themes/github-dark-orange/glow.scss
@@ -1,12 +1,11 @@
 @import "./variables";
 
-*:focus {
+*:focus-visible {
   outline: none !important;
   box-shadow: 0 0 0.2em 0.1em opacify($highlight, 0.1);
   border-radius: 1px;
 }
 
-.tabnav-tab,
 .form-control,
 .form-select {
   &.focus,

--- a/src/stylesheets/timeline-comment.scss
+++ b/src/stylesheets/timeline-comment.scss
@@ -49,6 +49,14 @@
     margin-bottom: 0;
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;
+
+    .tabnav-tabs[role="tablist"] {
+      padding: 2px 0 0 2px;
+
+      .tab-write {
+        margin-right: 2px;
+      }
+    }
   }
 
   .markdown-body {


### PR DESCRIPTION
## 1. Optimize the style of highlighted "tabnav-tab" button when accessed by the "tab" key

There are two highlighting methods in the existing themes: 

-  `outline`
- `box-shadow`

The following example uses the two themes `github-dark` and `github-dark-orange` as examples.

- `github-dark` => `outline`
- `github-dark-orange` => `box-shadow`

### `github-dark` before modification

#### “Write” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121331918-ea8f7d80-c949-11eb-8cdd-092a09ff110a.png)

#### “Preview” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121331948-f2e7b880-c949-11eb-9b90-f61811b91345.png)

### `github-dark` after modification

#### “Write” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121332462-7903ff00-c94a-11eb-8e26-ca8a7ea9f929.png)

#### “Preview” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121332489-7f927680-c94a-11eb-8141-3dbb5ccc13a5.png)

### `github-dark-orange` before modification

#### “Write” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121332631-a2248f80-c94a-11eb-96ed-19cf37c40c59.png)

#### “Preview” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121332669-a81a7080-c94a-11eb-93b7-7a8effc9485e.png)

### `github-dark-orange` after modification

#### “Write” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121332779-c5e7d580-c94a-11eb-8459-143dbcbf7b9b.png)

#### “Preview” button, when accessed by the "tab" key

![image](https://user-images.githubusercontent.com/44798353/121332822-ce401080-c94a-11eb-9d52-d479fc185a57.png)

## 2. Optimize the style when clicking the "tabnav-tab" button

This problem is because the "github-dark-orange" theme uses `:focus` for highlighting, it should use `:focus-visible`

### This is the comparison between the "github-dark" theme and the "github-dark-orange" theme before modification:

#### "github-dark":

![image](https://z3.ax1x.com/2021/06/09/2cEpIe.gif)

#### "github-dark-orange":

![image](https://z3.ax1x.com/2021/06/09/2cEYZT.gif)

### This is the "github-dark-orange" theme after modification:

![image](https://z3.ax1x.com/2021/06/09/2cEDQ1.gif)






