### PR TITLE
Fix #540: The number of comments on the last page is calculated incorrectly

### DIFF
--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -105,7 +105,8 @@ async function renderComments(issue: Issue, timeline: TimelineComponent) {
     pageLoads.push(loadCommentsPage(issue.number, pageCount));
   }
   // if the last page is small, load the penultimate page.
-  if (pageCount > 2 && issue.comments % PAGE_SIZE < 3) {
+  if (pageCount > 2 && issue.comments % PAGE_SIZE < 3 &&
+    issue.comments % PAGE_SIZE !== 0) {
     pageLoads.push(loadCommentsPage(issue.number, pageCount - 1));
   }
   // await all loads to reduce jank.


### PR DESCRIPTION
Closed #540 

After modification, the number of comments after the **"Load more..."** button will be limited to between 3 and 26.

### Before

```code
<Old comments> Quantity: 25

<Load more...>

<New comments> Quantity: 3 ~ 50
```

### After

```code
<Old comments> Quantity:  25

<Load more...>

<New comments> Quantity:  3 ~ 26
```