### PR TITLE
Allow different repo url patterns

### DIFF
--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -36,7 +36,26 @@ function readPageAttributes() {
     throw new Error('"origin" is required.');
   }
 
-  const matches = repoRegex.exec(params.repo);
+  let repo = params.repo;
+  let repoParts = repo.split('/');
+
+  if (repoParts.length >= 2) {
+    let repoOwner = repoParts[repoParts.length - 2];
+    let colonIndex = repoOwner.lastIndexOf(':');
+    if (colonIndex > -1 && repoOwner.length - 1 > colonIndex) {
+      repoOwner = repoOwner.substring(colonIndex + 1);
+    }
+
+    let repoName = repoParts[repoParts.length - 1];
+    let gitExtension = '.git';
+    if (repoName.endsWith(gitExtension)) {
+      repoName = repoName.substring(0, repoName.length - gitExtension.length - 1);
+    }
+
+    repo = repoOwner + '/' + repoName;
+  }
+
+  const matches = repoRegex.exec(repo);
   if (matches === null) {
     throw new Error(`Invalid repo: "${params.repo}"`);
   }


### PR DESCRIPTION
I find that there are people who can not figure out what to put in the repo parameter, myself included.

It's better to have more available options.

Given a repo https://github.com/utterance/utterances

**Before this change**
utterance/utterances

**After this change**
utterance/utterances
https://github.com/utterance/utterances
https://github.com/utterance/utterances.git
git@github.com:utterance/utterances.git