### PR TITLE
fix: fix border of tab button

### DIFF
--- a/src/stylesheets/themes/github-dark-orange/button.scss
+++ b/src/stylesheets/themes/github-dark-orange/button.scss
@@ -5,7 +5,9 @@
 }
 
 button[role=tab] {
+  margin: 0.1rem 0 0 0.1rem;
   color: $gray-600;
+
   .selected {
     color: $text-gray-dark;
   }

--- a/src/stylesheets/themes/gruvbox-dark/button.scss
+++ b/src/stylesheets/themes/gruvbox-dark/button.scss
@@ -5,7 +5,9 @@
 }
 
 button[role=tab] {
+  margin: 0.1rem 0 0 0.1rem;
   color: $light4;
+
   .selected {
     color: $light0;
   }


### PR DESCRIPTION
In theme `Dark Orange` and `GruvBox Dark`, when button is selected, some parts of button border seem to be cut off. So I  changed it into complete border (except bottom).

Here is the screenshot of this change.
![image](https://user-images.githubusercontent.com/37237235/151682236-1064caff-82e9-45ec-b7aa-e3930497d0ca.png)
