### PR TITLE
README: misleading lock-in statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A lightweight comments widget built on GitHub issues. Use GitHub issues for blog comments, wiki pages and more!
 
 - [Open source](https://github.com/utterance). 🙌
-- No tracking, no ads, always free. 📡🚫
-- No lock-in. All data stored in GitHub issues. 🔓
+- Comments tracked by Microsoft GitHub, free while Microsoft GitHub allows it. 📡
+- Comments are locked behind Microsoft GitHub accounts; commenters will be required to create an account, agreeing to Microsoft’s <abbr title="terms of service">ToS</abbr>, and cannot use an account from another code for or WebFinger-identified account or Fediverse option or <abbr title="Extensible Messaging and Presence Protocol">XMPP</abbr> pubsub-derived option. 🔒
 - Styled with [Primer](http://primer.style), the css toolkit that powers GitHub. 💅
 - Dark theme. 🌘
 - Lightweight. Vanilla TypeScript. No font downloads, JavaScript frameworks or polyfills for evergreen browsers. 🐦🌲


### PR DESCRIPTION
The documentation is wildly misleading. Everything in this project gets locked behind a US-based, for-profit, closed-source, proprietary service in Microsoft GitHub. It’s misleading to say that this isn’t tracked and has no lock-in, when it clearly does. We would be better off leveraging the *decentralized* part of distributed version control systems (DVCS) instead of centralizing around a service like Microsoft GitHub.

Feel free to close and fix the wording yourself. The rewording is facetious on purpose, but there is truth to the sentiment. (Merge requests always get more attention, and I’d email you a patch, but we’re locked into this platform’s source control model)
