### PR TITLE
[Theme] Port of Sakura CSS

### DIFF
--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -1,4 +1,4 @@
-import { preferredThemeId, preferredTheme } from './preferred-theme';
+import { preferredThemeId, preferredTheme } from "./preferred-theme";
 
 export class ConfigurationComponent {
   public readonly element: HTMLFormElement;
@@ -8,7 +8,7 @@ export class ConfigurationComponent {
   private readonly theme: HTMLSelectElement;
 
   constructor() {
-    this.element = document.createElement('form');
+    this.element = document.createElement("form");
     this.element.innerHTML = `
       <h3 id="heading-repository">Repository</h3>
       <p>
@@ -138,6 +138,8 @@ export class ConfigurationComponent {
         <option value="photon-dark">Photon Dark</option>
         <option value="boxy-light">Boxy Light</option>
         <option value="gruvbox-dark">Gruvbox Dark</option>
+        <option value="sakura">Sakura</option>
+        <option value="sakura-vader">Sakura Vader</option>
       </select>
 
       <h3 id="heading-enable">Enable Utterances</h3>
@@ -151,59 +153,80 @@ export class ConfigurationComponent {
       <br/>
       <br/>`;
 
-    this.element.addEventListener('submit', event => event.preventDefault());
-    this.element.action = 'javascript:';
+    this.element.addEventListener("submit", (event) => event.preventDefault());
+    this.element.action = "javascript:";
 
-    this.script = this.element.querySelector('#script') as HTMLDivElement;
+    this.script = this.element.querySelector("#script") as HTMLDivElement;
 
-    this.repo = this.element.querySelector('#repo') as HTMLInputElement;
+    this.repo = this.element.querySelector("#repo") as HTMLInputElement;
 
-    this.label = this.element.querySelector('#label') as HTMLInputElement;
+    this.label = this.element.querySelector("#label") as HTMLInputElement;
 
-    this.theme = this.element.querySelector('#theme') as HTMLSelectElement;
+    this.theme = this.element.querySelector("#theme") as HTMLSelectElement;
 
-    const themeStylesheet = document.getElementById('theme-stylesheet') as HTMLLinkElement;
-    this.theme.addEventListener('change', () => {
+    const themeStylesheet = document.getElementById(
+      "theme-stylesheet"
+    ) as HTMLLinkElement;
+    this.theme.addEventListener("change", () => {
       let theme = this.theme.value;
       if (theme === preferredThemeId) {
-        theme = preferredTheme
+        theme = preferredTheme;
       }
       themeStylesheet.href = `/stylesheets/themes/${theme}/index.css`;
       const message = {
-        type: 'set-theme',
-        theme
+        type: "set-theme",
+        theme,
       };
-      const utterances = document.querySelector('iframe')!;
+      const utterances = document.querySelector("iframe")!;
       utterances.contentWindow!.postMessage(message, location.origin);
     });
 
-    const copyButton = this.element.querySelector('#copy-button') as HTMLButtonElement;
-    copyButton.addEventListener(
-      'click',
-      () => this.copyTextToClipboard(this.script.textContent as string));
+    const copyButton = this.element.querySelector(
+      "#copy-button"
+    ) as HTMLButtonElement;
+    copyButton.addEventListener("click", () =>
+      this.copyTextToClipboard(this.script.textContent as string)
+    );
 
-    this.element.addEventListener('change', () => this.outputConfig());
-    this.element.addEventListener('input', () => this.outputConfig());
+    this.element.addEventListener("change", () => this.outputConfig());
+    this.element.addEventListener("input", () => this.outputConfig());
     this.outputConfig();
   }
 
   private outputConfig() {
-    const mapping = this.element.querySelector('input[name="mapping"]:checked') as HTMLInputElement;
+    const mapping = this.element.querySelector(
+      'input[name="mapping"]:checked'
+    ) as HTMLInputElement;
     let mappingAttr: string;
     // tslint:disable-next-line:prefer-conditional-expression
-    if (mapping.value === 'issue-number') {
-      mappingAttr = this.makeConfigScriptAttribute('issue-number', '[ENTER ISSUE NUMBER HERE]');
-    } else if (mapping.value === 'specific-term') {
-      mappingAttr = this.makeConfigScriptAttribute('issue-term', '[ENTER TERM HERE]');
+    if (mapping.value === "issue-number") {
+      mappingAttr = this.makeConfigScriptAttribute(
+        "issue-number",
+        "[ENTER ISSUE NUMBER HERE]"
+      );
+    } else if (mapping.value === "specific-term") {
+      mappingAttr = this.makeConfigScriptAttribute(
+        "issue-term",
+        "[ENTER TERM HERE]"
+      );
     } else {
-      mappingAttr = this.makeConfigScriptAttribute('issue-term', mapping.value);
+      mappingAttr = this.makeConfigScriptAttribute("issue-term", mapping.value);
     }
     this.script.innerHTML = this.makeConfigScript(
-      this.makeConfigScriptAttribute('repo', this.repo.value === '' ? '[ENTER REPO HERE]' : this.repo.value) + '\n' +
-      mappingAttr + '\n' +
-      (this.label.value ? this.makeConfigScriptAttribute('label', this.label.value) + '\n' : '') +
-      this.makeConfigScriptAttribute('theme', this.theme.value) + '\n' +
-      this.makeConfigScriptAttribute('crossorigin', 'anonymous'));
+      this.makeConfigScriptAttribute(
+        "repo",
+        this.repo.value === "" ? "[ENTER REPO HERE]" : this.repo.value
+      ) +
+        "\n" +
+        mappingAttr +
+        "\n" +
+        (this.label.value
+          ? this.makeConfigScriptAttribute("label", this.label.value) + "\n"
+          : "") +
+        this.makeConfigScriptAttribute("theme", this.theme.value) +
+        "\n" +
+        this.makeConfigScriptAttribute("crossorigin", "anonymous")
+    );
   }
 
   private makeConfigScriptAttribute(name: string, value: string) {
@@ -217,16 +240,16 @@ export class ConfigurationComponent {
   }
 
   private copyTextToClipboard(text: string) {
-    const textArea = document.createElement('textarea');
+    const textArea = document.createElement("textarea");
     // tslint:disable-next-line:max-line-length
     textArea.style.cssText = `position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent`;
     textArea.value = text;
     document.body.appendChild(textArea);
     textArea.select();
     try {
-      document.execCommand('copy');
+      document.execCommand("copy");
       // tslint:disable-next-line:no-empty
-    } catch (err) { }
+    } catch (err) {}
     document.body.removeChild(textArea);
   }
 }

--- a/src/configuration-component.ts
+++ b/src/configuration-component.ts
@@ -1,4 +1,4 @@
-import { preferredThemeId, preferredTheme } from "./preferred-theme";
+import { preferredThemeId, preferredTheme } from './preferred-theme';
 
 export class ConfigurationComponent {
   public readonly element: HTMLFormElement;
@@ -8,7 +8,7 @@ export class ConfigurationComponent {
   private readonly theme: HTMLSelectElement;
 
   constructor() {
-    this.element = document.createElement("form");
+    this.element = document.createElement('form');
     this.element.innerHTML = `
       <h3 id="heading-repository">Repository</h3>
       <p>
@@ -153,80 +153,59 @@ export class ConfigurationComponent {
       <br/>
       <br/>`;
 
-    this.element.addEventListener("submit", (event) => event.preventDefault());
-    this.element.action = "javascript:";
+    this.element.addEventListener('submit', event => event.preventDefault());
+    this.element.action = 'javascript:';
 
-    this.script = this.element.querySelector("#script") as HTMLDivElement;
+    this.script = this.element.querySelector('#script') as HTMLDivElement;
 
-    this.repo = this.element.querySelector("#repo") as HTMLInputElement;
+    this.repo = this.element.querySelector('#repo') as HTMLInputElement;
 
-    this.label = this.element.querySelector("#label") as HTMLInputElement;
+    this.label = this.element.querySelector('#label') as HTMLInputElement;
 
-    this.theme = this.element.querySelector("#theme") as HTMLSelectElement;
+    this.theme = this.element.querySelector('#theme') as HTMLSelectElement;
 
-    const themeStylesheet = document.getElementById(
-      "theme-stylesheet"
-    ) as HTMLLinkElement;
-    this.theme.addEventListener("change", () => {
+    const themeStylesheet = document.getElementById('theme-stylesheet') as HTMLLinkElement;
+    this.theme.addEventListener('change', () => {
       let theme = this.theme.value;
       if (theme === preferredThemeId) {
-        theme = preferredTheme;
+        theme = preferredTheme
       }
       themeStylesheet.href = `/stylesheets/themes/${theme}/index.css`;
       const message = {
-        type: "set-theme",
-        theme,
+        type: 'set-theme',
+        theme
       };
-      const utterances = document.querySelector("iframe")!;
+      const utterances = document.querySelector('iframe')!;
       utterances.contentWindow!.postMessage(message, location.origin);
     });
 
-    const copyButton = this.element.querySelector(
-      "#copy-button"
-    ) as HTMLButtonElement;
-    copyButton.addEventListener("click", () =>
-      this.copyTextToClipboard(this.script.textContent as string)
-    );
+    const copyButton = this.element.querySelector('#copy-button') as HTMLButtonElement;
+    copyButton.addEventListener(
+      'click',
+      () => this.copyTextToClipboard(this.script.textContent as string));
 
-    this.element.addEventListener("change", () => this.outputConfig());
-    this.element.addEventListener("input", () => this.outputConfig());
+    this.element.addEventListener('change', () => this.outputConfig());
+    this.element.addEventListener('input', () => this.outputConfig());
     this.outputConfig();
   }
 
   private outputConfig() {
-    const mapping = this.element.querySelector(
-      'input[name="mapping"]:checked'
-    ) as HTMLInputElement;
+    const mapping = this.element.querySelector('input[name="mapping"]:checked') as HTMLInputElement;
     let mappingAttr: string;
     // tslint:disable-next-line:prefer-conditional-expression
-    if (mapping.value === "issue-number") {
-      mappingAttr = this.makeConfigScriptAttribute(
-        "issue-number",
-        "[ENTER ISSUE NUMBER HERE]"
-      );
-    } else if (mapping.value === "specific-term") {
-      mappingAttr = this.makeConfigScriptAttribute(
-        "issue-term",
-        "[ENTER TERM HERE]"
-      );
+    if (mapping.value === 'issue-number') {
+      mappingAttr = this.makeConfigScriptAttribute('issue-number', '[ENTER ISSUE NUMBER HERE]');
+    } else if (mapping.value === 'specific-term') {
+      mappingAttr = this.makeConfigScriptAttribute('issue-term', '[ENTER TERM HERE]');
     } else {
-      mappingAttr = this.makeConfigScriptAttribute("issue-term", mapping.value);
+      mappingAttr = this.makeConfigScriptAttribute('issue-term', mapping.value);
     }
     this.script.innerHTML = this.makeConfigScript(
-      this.makeConfigScriptAttribute(
-        "repo",
-        this.repo.value === "" ? "[ENTER REPO HERE]" : this.repo.value
-      ) +
-        "\n" +
-        mappingAttr +
-        "\n" +
-        (this.label.value
-          ? this.makeConfigScriptAttribute("label", this.label.value) + "\n"
-          : "") +
-        this.makeConfigScriptAttribute("theme", this.theme.value) +
-        "\n" +
-        this.makeConfigScriptAttribute("crossorigin", "anonymous")
-    );
+      this.makeConfigScriptAttribute('repo', this.repo.value === '' ? '[ENTER REPO HERE]' : this.repo.value) + '\n' +
+      mappingAttr + '\n' +
+      (this.label.value ? this.makeConfigScriptAttribute('label', this.label.value) + '\n' : '') +
+      this.makeConfigScriptAttribute('theme', this.theme.value) + '\n' +
+      this.makeConfigScriptAttribute('crossorigin', 'anonymous'));
   }
 
   private makeConfigScriptAttribute(name: string, value: string) {
@@ -240,16 +219,16 @@ export class ConfigurationComponent {
   }
 
   private copyTextToClipboard(text: string) {
-    const textArea = document.createElement("textarea");
+    const textArea = document.createElement('textarea');
     // tslint:disable-next-line:max-line-length
     textArea.style.cssText = `position:fixed;top:0;left:0;width:2em;height:2em;padding:0;border:none;outline:none;box-shadow:none;background:transparent`;
     textArea.value = text;
     document.body.appendChild(textArea);
     textArea.select();
     try {
-      document.execCommand("copy");
+      document.execCommand('copy');
       // tslint:disable-next-line:no-empty
-    } catch (err) {}
+    } catch (err) { }
     document.body.removeChild(textArea);
   }
 }

--- a/src/stylesheets/themes/sakura-vader/button.scss
+++ b/src/stylesheets/themes/sakura-vader/button.scss
@@ -1,0 +1,21 @@
+@import "./variables";
+
+.btn-primary {
+	background-color: $color-blossom;
+	border: 1px solid $color-blossom;
+  color: $color-bg;
+
+	.octicon{
+		color: $color-bg;
+	}
+}
+
+.btn-primary:hover {
+	background-color: $color-fade;
+	color: $color-bg;
+	outline: 0;
+}
+
+.btn-primary:disabled {
+	opacity: .5;
+}

--- a/src/stylesheets/themes/sakura-vader/index.scss
+++ b/src/stylesheets/themes/sakura-vader/index.scss
@@ -1,0 +1,19 @@
+@import "./variables";
+@import "../../index";
+@import "./syntax";
+@import "./button.scss";
+
+a {
+	text-decoration: none;
+	color: $color-blossom;
+
+	&:visited {
+		color: darken($color-blossom, 10%);
+	}
+
+	&:hover {
+		text-decoration: none;
+		color: $color-fade;
+		border-bottom: 2px solid $color-text;
+	}
+}

--- a/src/stylesheets/themes/sakura-vader/sakura-vader.scss
+++ b/src/stylesheets/themes/sakura-vader/sakura-vader.scss
@@ -1,0 +1,13 @@
+$color-force: #DA4453;
+$color-blossom: lighten($color-force, 20%);
+$color-fade: $color-force;
+
+$color-bg: #120c0e;
+$color-bg-alt: #40363a;
+
+/* $color-text: #dedce5; */
+$color-text: #d9d8dc;
+$font-size-base: 1.8rem;
+
+$font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+$font-family-heading: $font-family-base;

--- a/src/stylesheets/themes/sakura-vader/syntax.scss
+++ b/src/stylesheets/themes/sakura-vader/syntax.scss
@@ -1,0 +1,1 @@
+@import "github-syntax-dark/lib/github-dark";

--- a/src/stylesheets/themes/sakura-vader/utterances.scss
+++ b/src/stylesheets/themes/sakura-vader/utterances.scss
@@ -1,0 +1,21 @@
+@import "./variables";
+@import "../../utterances";
+@import "./syntax";
+@import "./button.scss";
+
+.timeline-comment {
+	a {
+			text-decoration: none;
+			color: $color-blossom;
+	
+			&:visited {
+				color: darken($color-blossom, 10%);
+			}
+	
+			&:hover {
+				text-decoration: none;
+				color: $color-fade;
+				border-bottom: 2px solid $color-text;
+			}	
+		}
+}

--- a/src/stylesheets/themes/sakura-vader/variables.scss
+++ b/src/stylesheets/themes/sakura-vader/variables.scss
@@ -1,0 +1,22 @@
+@import "./sakura-vader.scss";
+
+/* Icy-Dark overwrites */
+
+$gray-000: $color-blossom;
+$gray-100: $color-blossom;
+$gray-200: $color-blossom;
+$gray-300: $color-blossom;
+$gray-400: $color-text;
+$gray-600: $color-text;
+$gray-700: $color-text;
+$bg-white: $color-bg;
+$bg-gray: $color-bg-alt;
+$bg-gray-light: darken($bg-gray, 5%);
+$border-gray: $color-bg-alt;
+$border-gray-dark: $border-gray;
+$text-gray: $color-text;
+$text-gray-dark: $color-text;
+$text-blue: $color-blossom;
+$bg-blue-light: $color-blossom;
+$black-fade-15: rgba(#fff, 0.15);
+$black-fade-30: rgba(#fff, 0.3);

--- a/src/stylesheets/themes/sakura/button.scss
+++ b/src/stylesheets/themes/sakura/button.scss
@@ -1,0 +1,21 @@
+@import "./variables";
+
+.btn-primary {
+	background-color: $color-blossom;
+	border: 1px solid $color-blossom;
+  color: $color-bg;
+
+	.octicon{
+		color: $color-bg;
+	}
+}
+
+.btn-primary:hover {
+	background-color: $color-fade;
+	color: $color-bg;
+	outline: 0;
+}
+
+.btn-primary:disabled {
+	opacity: .5;
+}

--- a/src/stylesheets/themes/sakura/index.scss
+++ b/src/stylesheets/themes/sakura/index.scss
@@ -1,0 +1,19 @@
+@import "./variables";
+@import "../../index";
+@import "./syntax";
+@import "./button.scss";
+
+a {
+	text-decoration: none;
+	color: $color-blossom;
+
+	&:visited {
+		color: darken($color-blossom, 10%);
+	}
+
+	&:hover {
+		text-decoration: none;
+		color: $color-fade;
+		border-bottom: 2px solid $color-text;
+	}
+}

--- a/src/stylesheets/themes/sakura/sakura.scss
+++ b/src/stylesheets/themes/sakura/sakura.scss
@@ -1,0 +1,11 @@
+$color-blossom: #1d7484;
+$color-fade: #982c61;
+
+$color-bg: #f9f9f9;
+$color-bg-alt: #f1f1f1;
+
+$color-text: #4a4a4a;
+$font-size-base: 1.8rem;
+
+$font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+$font-family-heading: $font-family-base;

--- a/src/stylesheets/themes/sakura/syntax.scss
+++ b/src/stylesheets/themes/sakura/syntax.scss
@@ -1,0 +1,1 @@
+@import "github-syntax-dark/lib/github-dark";

--- a/src/stylesheets/themes/sakura/syntax.scss
+++ b/src/stylesheets/themes/sakura/syntax.scss
@@ -1,1 +1,1 @@
-@import "github-syntax-dark/lib/github-dark";
+@import "github-syntax-light/lib/github-light";

--- a/src/stylesheets/themes/sakura/utterances.scss
+++ b/src/stylesheets/themes/sakura/utterances.scss
@@ -1,0 +1,21 @@
+@import "./variables";
+@import "../../utterances";
+@import "./syntax";
+@import "./button.scss";
+
+.timeline-comment {
+	a {
+			text-decoration: none;
+			color: $color-blossom;
+	
+			&:visited {
+				color: darken($color-blossom, 10%);
+			}
+	
+			&:hover {
+				text-decoration: none;
+				color: $color-fade;
+				border-bottom: 2px solid $color-text;
+			}	
+		}
+}

--- a/src/stylesheets/themes/sakura/variables.scss
+++ b/src/stylesheets/themes/sakura/variables.scss
@@ -1,0 +1,22 @@
+@import "./sakura.scss";
+
+/* Icy-Dark overwrites */
+
+$gray-000: $color-blossom;
+$gray-100: $color-blossom;
+$gray-200: $color-blossom;
+$gray-300: $color-blossom;
+$gray-400: $color-text;
+$gray-600: $color-text;
+$gray-700: $color-text;
+$bg-white: $color-bg;
+$bg-gray: $color-bg-alt;
+$bg-gray-light: darken($bg-gray, 5%);
+$border-gray: $color-bg-alt;
+$border-gray-dark: $border-gray;
+$text-gray: $color-text;
+$text-gray-dark: $color-text;
+$text-blue: $color-blossom;
+$bg-blue-light: $color-blossom;
+$black-fade-15: rgba(#fff, 0.15);
+$black-fade-30: rgba(#fff, 0.3);


### PR DESCRIPTION
This PR ports Sakura CSS ( https://github.com/oxalorg/sakura ) to utterances with it's main theme and its dark variant `sakura-vader`. Sakura CSS has a sizeable user base, among of which is my blog. (Example post with comments: https://blog.frost.kiwi/analytical-anti-aliasing/ )

Technically, it simply imports the variable file of sakura.css and maps them. So should someone desire to import the rest of Sakura.css's variants, it's simply a copy paste of the variables files from: https://github.com/oxalorg/sakura/tree/master/scss

I use utterances and would love for the comments to follow Sakura CSS, which this PR puts in motion.
| Before | After |
|--------|-------|
|  ![image](https://github.com/user-attachments/assets/6e9727b1-5e06-4efc-871c-39e397ce67bf)     |    ![image](https://github.com/user-attachments/assets/9b722a71-ff73-4017-96e7-3f237538a9f1)   |

| Sakura| Sakura-Vader |
|--------|-------|
|  ![image](https://github.com/user-attachments/assets/b85e8966-99aa-4f14-849e-4872fe0738ba)     |    ![image](https://github.com/user-attachments/assets/da8ad0bb-c195-4784-9fd6-2457a09c5b3b)   |