### PR TITLE
Loading Spinner

### DIFF
--- a/src/stylesheets/utterances.scss
+++ b/src/stylesheets/utterances.scss
@@ -38,180 +38,180 @@ textarea[disabled] {
 }
 
 #loadingSpinner {
-	position: relative;
-	width: 234px;
-	height: 28px;
-	margin: auto;
+  position: relative;
+  width: 234px;
+  height: 28px;
+  margin: auto;
 }
 
 .fountainG {
-	position: absolute;
-	top: 0;
-	background-color: transparent;
-	width: 28px;
-	height: 28px;
-	animation-name: bounce_fountainG;
-	-o-animation-name: bounce_fountainG;
-	-ms-animation-name: bounce_fountainG;
-	-webkit-animation-name: bounce_fountainG;
-	-moz-animation-name: bounce_fountainG;
-	animation-duration: 1.5s;
-	-o-animation-duration: 1.5s;
-	-ms-animation-duration: 1.5s;
-	-webkit-animation-duration: 1.5s;
-	-moz-animation-duration: 1.5s;
-	animation-iteration-count: infinite;
-	-o-animation-iteration-count: infinite;
-	-ms-animation-iteration-count: infinite;
-	-webkit-animation-iteration-count: infinite;
-	-moz-animation-iteration-count: infinite;
-	animation-direction: normal;
-	-o-animation-direction: normal;
-	-ms-animation-direction: normal;
-	-webkit-animation-direction: normal;
-	-moz-animation-direction: normal;
-	transform: scale(.3);
-	-o-transform: scale(.3);
-	-ms-transform: scale(.3);
-	-webkit-transform: scale(.3);
-	-moz-transform: scale(.3);
-	border-radius: 19px;
-	-o-border-radius: 19px;
-	-ms-border-radius: 19px;
-	-webkit-border-radius: 19px;
-	-moz-border-radius: 19px;
+  position: absolute;
+  top: 0;
+  background-color: transparent;
+  width: 28px;
+  height: 28px;
+  animation-name: bounce_fountainG;
+  -o-animation-name: bounce_fountainG;
+  -ms-animation-name: bounce_fountainG;
+  -webkit-animation-name: bounce_fountainG;
+  -moz-animation-name: bounce_fountainG;
+  animation-duration: 1.5s;
+  -o-animation-duration: 1.5s;
+  -ms-animation-duration: 1.5s;
+  -webkit-animation-duration: 1.5s;
+  -moz-animation-duration: 1.5s;
+  animation-iteration-count: infinite;
+  -o-animation-iteration-count: infinite;
+  -ms-animation-iteration-count: infinite;
+  -webkit-animation-iteration-count: infinite;
+  -moz-animation-iteration-count: infinite;
+  animation-direction: normal;
+  -o-animation-direction: normal;
+  -ms-animation-direction: normal;
+  -webkit-animation-direction: normal;
+  -moz-animation-direction: normal;
+  transform: scale(.3);
+  -o-transform: scale(.3);
+  -ms-transform: scale(.3);
+  -webkit-transform: scale(.3);
+  -moz-transform: scale(.3);
+  border-radius: 19px;
+  -o-border-radius: 19px;
+  -ms-border-radius: 19px;
+  -webkit-border-radius: 19px;
+  -moz-border-radius: 19px;
 }
 
 #fountainG_1 {
-	left: 0;
-	animation-delay: 0.6s;
-	-o-animation-delay: 0.6s;
-	-ms-animation-delay: 0.6s;
-	-webkit-animation-delay: 0.6s;
-	-moz-animation-delay: 0.6s;
+  left: 0;
+  animation-delay: 0.6s;
+  -o-animation-delay: 0.6s;
+  -ms-animation-delay: 0.6s;
+  -webkit-animation-delay: 0.6s;
+  -moz-animation-delay: 0.6s;
 }
 
 #fountainG_2 {
-	left: 29px;
-	animation-delay: 0.75s;
-	-o-animation-delay: 0.75s;
-	-ms-animation-delay: 0.75s;
-	-webkit-animation-delay: 0.75s;
-	-moz-animation-delay: 0.75s;
+  left: 29px;
+  animation-delay: 0.75s;
+  -o-animation-delay: 0.75s;
+  -ms-animation-delay: 0.75s;
+  -webkit-animation-delay: 0.75s;
+  -moz-animation-delay: 0.75s;
 }
 
 #fountainG_3 {
-	left: 58px;
-	animation-delay: 0.9s;
-	-o-animation-delay: 0.9s;
-	-ms-animation-delay: 0.9s;
-	-webkit-animation-delay: 0.9s;
-	-moz-animation-delay: 0.9s;
+  left: 58px;
+  animation-delay: 0.9s;
+  -o-animation-delay: 0.9s;
+  -ms-animation-delay: 0.9s;
+  -webkit-animation-delay: 0.9s;
+  -moz-animation-delay: 0.9s;
 }
 
 #fountainG_4 {
-	left: 88px;
-	animation-delay: 1.05s;
-	-o-animation-delay: 1.05s;
-	-ms-animation-delay: 1.05s;
-	-webkit-animation-delay: 1.05s;
-	-moz-animation-delay: 1.05s;
+  left: 88px;
+  animation-delay: 1.05s;
+  -o-animation-delay: 1.05s;
+  -ms-animation-delay: 1.05s;
+  -webkit-animation-delay: 1.05s;
+  -moz-animation-delay: 1.05s;
 }
 
 #fountainG_5 {
-	left: 117px;
-	animation-delay: 1.2s;
-	-o-animation-delay: 1.2s;
-	-ms-animation-delay: 1.2s;
-	-webkit-animation-delay: 1.2s;
-	-moz-animation-delay: 1.2s;
+  left: 117px;
+  animation-delay: 1.2s;
+  -o-animation-delay: 1.2s;
+  -ms-animation-delay: 1.2s;
+  -webkit-animation-delay: 1.2s;
+  -moz-animation-delay: 1.2s;
 }
 
 #fountainG_6 {
-	left: 146px;
-	animation-delay: 1.35s;
-	-o-animation-delay: 1.35s;
-	-ms-animation-delay: 1.35s;
-	-webkit-animation-delay: 1.35s;
-	-moz-animation-delay: 1.35s;
+  left: 146px;
+  animation-delay: 1.35s;
+  -o-animation-delay: 1.35s;
+  -ms-animation-delay: 1.35s;
+  -webkit-animation-delay: 1.35s;
+  -moz-animation-delay: 1.35s;
 }
 
 #fountainG_7 {
-	left: 175px;
-	animation-delay: 1.5s;
-	-o-animation-delay: 1.5s;
-	-ms-animation-delay: 1.5s;
-	-webkit-animation-delay: 1.5s;
-	-moz-animation-delay: 1.5s;
+  left: 175px;
+  animation-delay: 1.5s;
+  -o-animation-delay: 1.5s;
+  -ms-animation-delay: 1.5s;
+  -webkit-animation-delay: 1.5s;
+  -moz-animation-delay: 1.5s;
 }
 
 #fountainG_8 {
-	left: 205px;
-	animation-delay: 1.64s;
-	-o-animation-delay: 1.64s;
-	-ms-animation-delay: 1.64s;
-	-webkit-animation-delay: 1.64s;
-	-moz-animation-delay: 1.64s;
+  left: 205px;
+  animation-delay: 1.64s;
+  -o-animation-delay: 1.64s;
+  -ms-animation-delay: 1.64s;
+  -webkit-animation-delay: 1.64s;
+  -moz-animation-delay: 1.64s;
 }
 
 
 
 @keyframes bounce_fountainG {
-	0% {
-		transform: scale(1);
-		background-color: $text-blue;
-	}
+  0% {
+    transform: scale(1);
+    background-color: $text-blue;
+  }
 
-	100% {
-		transform: scale(.3);
-		background-color: transparent;
-	}
+  100% {
+    transform: scale(.3);
+    background-color: transparent;
+  }
 }
 
 @-o-keyframes bounce_fountainG {
-	0% {
-		-o-transform: scale(1);
-		background-color: $text-blue;
-	}
+  0% {
+    -o-transform: scale(1);
+    background-color: $text-blue;
+  }
 
-	100% {
-		-o-transform: scale(.3);
-		background-color: transparent;
-	}
+  100% {
+    -o-transform: scale(.3);
+    background-color: transparent;
+  }
 }
 
 @-ms-keyframes bounce_fountainG {
-	0% {
-		-ms-transform: scale(1);
-		background-color: $text-blue;
-	}
+  0% {
+    -ms-transform: scale(1);
+    background-color: $text-blue;
+  }
 
-	100% {
-		-ms-transform: scale(.3);
-		background-color: transparent;
-	}
+  100% {
+    -ms-transform: scale(.3);
+    background-color: transparent;
+  }
 }
 
 @-webkit-keyframes bounce_fountainG {
-	0% {
-		-webkit-transform: scale(1);
-		background-color: $text-blue;
-	}
+  0% {
+    -webkit-transform: scale(1);
+    background-color: $text-blue;
+  }
 
-	100% {
-		-webkit-transform: scale(.3);
-		background-color: transparent;
-	}
+  100% {
+    -webkit-transform: scale(.3);
+    background-color: transparent;
+  }
 }
 
 @-moz-keyframes bounce_fountainG {
-	0% {
-		-moz-transform: scale(1);
-		background-color: $text-blue;
-	}
+  0% {
+    -moz-transform: scale(1);
+    background-color: $text-blue;
+  }
 
-	100% {
-		-moz-transform: scale(.3);
-		background-color: transparent;
-	}
+  100% {
+    -moz-transform: scale(.3);
+    background-color: transparent;
+  }
 }

--- a/src/stylesheets/utterances.scss
+++ b/src/stylesheets/utterances.scss
@@ -36,3 +36,182 @@ body {
 textarea[disabled] {
   cursor: not-allowed;
 }
+
+#loadingSpinner {
+	position: relative;
+	width: 234px;
+	height: 28px;
+	margin: auto;
+}
+
+.fountainG {
+	position: absolute;
+	top: 0;
+	background-color: transparent;
+	width: 28px;
+	height: 28px;
+	animation-name: bounce_fountainG;
+	-o-animation-name: bounce_fountainG;
+	-ms-animation-name: bounce_fountainG;
+	-webkit-animation-name: bounce_fountainG;
+	-moz-animation-name: bounce_fountainG;
+	animation-duration: 1.5s;
+	-o-animation-duration: 1.5s;
+	-ms-animation-duration: 1.5s;
+	-webkit-animation-duration: 1.5s;
+	-moz-animation-duration: 1.5s;
+	animation-iteration-count: infinite;
+	-o-animation-iteration-count: infinite;
+	-ms-animation-iteration-count: infinite;
+	-webkit-animation-iteration-count: infinite;
+	-moz-animation-iteration-count: infinite;
+	animation-direction: normal;
+	-o-animation-direction: normal;
+	-ms-animation-direction: normal;
+	-webkit-animation-direction: normal;
+	-moz-animation-direction: normal;
+	transform: scale(.3);
+	-o-transform: scale(.3);
+	-ms-transform: scale(.3);
+	-webkit-transform: scale(.3);
+	-moz-transform: scale(.3);
+	border-radius: 19px;
+	-o-border-radius: 19px;
+	-ms-border-radius: 19px;
+	-webkit-border-radius: 19px;
+	-moz-border-radius: 19px;
+}
+
+#fountainG_1 {
+	left: 0;
+	animation-delay: 0.6s;
+	-o-animation-delay: 0.6s;
+	-ms-animation-delay: 0.6s;
+	-webkit-animation-delay: 0.6s;
+	-moz-animation-delay: 0.6s;
+}
+
+#fountainG_2 {
+	left: 29px;
+	animation-delay: 0.75s;
+	-o-animation-delay: 0.75s;
+	-ms-animation-delay: 0.75s;
+	-webkit-animation-delay: 0.75s;
+	-moz-animation-delay: 0.75s;
+}
+
+#fountainG_3 {
+	left: 58px;
+	animation-delay: 0.9s;
+	-o-animation-delay: 0.9s;
+	-ms-animation-delay: 0.9s;
+	-webkit-animation-delay: 0.9s;
+	-moz-animation-delay: 0.9s;
+}
+
+#fountainG_4 {
+	left: 88px;
+	animation-delay: 1.05s;
+	-o-animation-delay: 1.05s;
+	-ms-animation-delay: 1.05s;
+	-webkit-animation-delay: 1.05s;
+	-moz-animation-delay: 1.05s;
+}
+
+#fountainG_5 {
+	left: 117px;
+	animation-delay: 1.2s;
+	-o-animation-delay: 1.2s;
+	-ms-animation-delay: 1.2s;
+	-webkit-animation-delay: 1.2s;
+	-moz-animation-delay: 1.2s;
+}
+
+#fountainG_6 {
+	left: 146px;
+	animation-delay: 1.35s;
+	-o-animation-delay: 1.35s;
+	-ms-animation-delay: 1.35s;
+	-webkit-animation-delay: 1.35s;
+	-moz-animation-delay: 1.35s;
+}
+
+#fountainG_7 {
+	left: 175px;
+	animation-delay: 1.5s;
+	-o-animation-delay: 1.5s;
+	-ms-animation-delay: 1.5s;
+	-webkit-animation-delay: 1.5s;
+	-moz-animation-delay: 1.5s;
+}
+
+#fountainG_8 {
+	left: 205px;
+	animation-delay: 1.64s;
+	-o-animation-delay: 1.64s;
+	-ms-animation-delay: 1.64s;
+	-webkit-animation-delay: 1.64s;
+	-moz-animation-delay: 1.64s;
+}
+
+
+
+@keyframes bounce_fountainG {
+	0% {
+		transform: scale(1);
+		background-color: $text-blue;
+	}
+
+	100% {
+		transform: scale(.3);
+		background-color: transparent;
+	}
+}
+
+@-o-keyframes bounce_fountainG {
+	0% {
+		-o-transform: scale(1);
+		background-color: $text-blue;
+	}
+
+	100% {
+		-o-transform: scale(.3);
+		background-color: transparent;
+	}
+}
+
+@-ms-keyframes bounce_fountainG {
+	0% {
+		-ms-transform: scale(1);
+		background-color: $text-blue;
+	}
+
+	100% {
+		-ms-transform: scale(.3);
+		background-color: transparent;
+	}
+}
+
+@-webkit-keyframes bounce_fountainG {
+	0% {
+		-webkit-transform: scale(1);
+		background-color: $text-blue;
+	}
+
+	100% {
+		-webkit-transform: scale(.3);
+		background-color: transparent;
+	}
+}
+
+@-moz-keyframes bounce_fountainG {
+	0% {
+		-moz-transform: scale(1);
+		background-color: $text-blue;
+	}
+
+	100% {
+		-moz-transform: scale(.3);
+		background-color: transparent;
+	}
+}

--- a/src/utterances.html
+++ b/src/utterances.html
@@ -17,7 +17,7 @@
 		     a project by Timur Gafforov, Timur Yerzin and Avraam Makhmudov -->
 		<div style="display: none;" id="loadingSpinner">
 			<!-- Hidden by default, turned on by TypeScript to ensure users with JS
-			     off won't get an endless loading spinner. It actually doesn't matter,
+					 off won't get an endless loading spinner. It actually doesn't matter,
 					 since without a resize this will be invisible, but just in case, it
 					 is hidden by default. -->
 			<div id="fountainG_1" class="fountainG"></div>

--- a/src/utterances.html
+++ b/src/utterances.html
@@ -12,5 +12,22 @@
     <link rel="preconnect" href="https://avatars3.githubusercontent.com" />
     <script type="module" src="./utterances.ts"></script>
   </head>
-  <body></body>
+  <body>
+		<!-- Reference not required but still: Loader created by http://cssload.net,
+		     a project by Timur Gafforov, Timur Yerzin and Avraam Makhmudov -->
+		<div style="display: none;" id="loadingSpinner">
+			<!-- Hidden by default, turned on by TypeScript to ensure users with JS
+			     off won't get an endless loading spinner. It actually doesn't matter,
+					 since without a resize this will be invisible, but just in case, it
+					 is hidden by default. -->
+			<div id="fountainG_1" class="fountainG"></div>
+			<div id="fountainG_2" class="fountainG"></div>
+			<div id="fountainG_3" class="fountainG"></div>
+			<div id="fountainG_4" class="fountainG"></div>
+			<div id="fountainG_5" class="fountainG"></div>
+			<div id="fountainG_6" class="fountainG"></div>
+			<div id="fountainG_7" class="fountainG"></div>
+			<div id="fountainG_8" class="fountainG"></div>
+		</div>
+	</body>
 </html>

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -81,8 +81,6 @@ async function bootstrap() {
 
   const newCommentComponent = new NewCommentComponent(user, submit);
   timeline.element.appendChild(newCommentComponent.element);
-
-
 }
 
 bootstrap();

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -29,17 +29,25 @@ function loadIssue(): Promise<Issue | null> {
 }
 
 async function bootstrap() {
+	/* Enable the loading spinner */
+	await loadTheme(page.theme, page.origin);
+	document.getElementById('loadingSpinner')!.style.display = 'block';
+	scheduleMeasure();
+
   await loadToken();
   // tslint:disable-next-line:prefer-const
   let [issue, user] = await Promise.all([
     loadIssue(),
-    loadUser(),
-    loadTheme(page.theme, page.origin)
+    loadUser()
   ]);
 
   startMeasuring(page.origin);
 
   const timeline = new TimelineComponent(user, issue);
+
+	/* Disable the loading spinner */
+	document.getElementById('loadingSpinner')!.style.display = 'none';
+
   document.body.appendChild(timeline.element);
 
   if (issue && issue.comments > 0) {
@@ -73,6 +81,8 @@ async function bootstrap() {
 
   const newCommentComponent = new NewCommentComponent(user, submit);
   timeline.element.appendChild(newCommentComponent.element);
+
+
 }
 
 bootstrap();


### PR DESCRIPTION
Solves https://github.com/utterance/utterances/issues/564
Utterances doesn't have a loading spinner. This is fatal, because if GitHub's API doesn't respond quickly, Utterances shows *nothing*, making the user think the feature is broken and scroll away before the loading is complete.
I see it especially on the Smartphone, when connection isn't the best and you scroll down to the comments section.

This PR adds a loading spinner, that respects the Theme set by the user, see gifs below. The colors are taken from the Theme file variables.

| Github-Light | Github-Dark |
|--------|-------|
|    ![ezgif-2-11a886846c](https://github.com/user-attachments/assets/6629e71c-540c-463c-8bc6-54abe353bf47)    |   ![ezgif-2-b455666da4](https://github.com/user-attachments/assets/e7a02cc5-9caf-40d1-a686-e5ff41cf0e93)    |
| Gruvbox-Dark | [Sakura-Vader](https://github.com/utterance/utterances/pull/677) |
|   ![ezgif-2-28eee88f9f](https://github.com/user-attachments/assets/eb3e86db-c208-47a0-8bb0-a5ac8bf46dca)     |    ![ezgif-2-c6797c6bfb](https://github.com/user-attachments/assets/5d7d0a19-7da2-45d2-9ea0-a10d4348d35e)   |