### PR TITLE
feat: support configurable branch name for 'main' and other defaults (fixes #523)

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -15,11 +15,14 @@ export const reactionTypes: ReactionID[] = ['+1', '-1', 'laugh', 'hooray', 'conf
 
 let owner: string;
 let repo: string;
-const branch = 'master';
+let branch = 'master';
 
-export function setRepoContext(context: { owner: string; repo: string; }) {
+export function setRepoContext(context: { owner: string; repo: string; branch?: string; }) {
   owner = context.owner;
   repo = context.repo;
+  if (context.branch) {
+    branch = context.branch;
+  }
 }
 
 function githubRequest(relativeUrl: string, init?: RequestInit) {

--- a/src/page-attributes.ts
+++ b/src/page-attributes.ts
@@ -51,7 +51,8 @@ function readPageAttributes() {
     description: params.description,
     label: params.label,
     theme: params.theme || 'github-light',
-    session: params.session
+    session: params.session,
+    branch: params.branch || 'master'
   };
 }
 

--- a/src/utterances.ts
+++ b/src/utterances.ts
@@ -138,7 +138,7 @@ async function renderComments(issue: Issue, timeline: TimelineComponent) {
 
 export async function assertOrigin() {
   const { origins } = await getRepoConfig();
-  const { origin, owner, repo } = page;
+  const { origin, owner, repo, branch } = page;
   if (origins.indexOf(origin) !== -1) {
     return;
   }
@@ -147,7 +147,7 @@ export async function assertOrigin() {
   <div class="flash flash-error flash-not-installed">
     Error: <code>${origin}</code> is not permitted to post to <code>${owner}/${repo}</code>.
     Confirm this is the correct repo for this site's comments. If you own this repo,
-    <a href="https://github.com/${owner}/${repo}/edit/master/utterances.json" target="_top">
+    <a href="https://github.com/${owner}/${repo}/edit/${branch}/utterances.json" target="_top">
       <strong>update the utterances.json</strong>
     </a>
     to include <code>${origin}</code> in the list of origins.<br/><br/>


### PR DESCRIPTION
## Description

Fixes #523

The branch name was hardcoded as 'master', causing the whitelist feature to fail when repositories use 'main' or other default branch names.

## Changes

- Add 'branch' parameter to page-attributes (defaults to 'master')
- Make branch variable in github.ts configurable via setRepoContext()
- Update error message link to use the configured branch

## Usage

Users can now specify the branch name in the utterances script tag:



If not specified, defaults to 'master' for backward compatibility.